### PR TITLE
Feature/build without deps script

### DIFF
--- a/avcodec.go
+++ b/avcodec.go
@@ -1,14 +1,11 @@
 package lilliput
 
 // #cgo CFLAGS: -msse -msse2 -msse3 -msse4.1 -msse4.2 -mavx
-// #cgo darwin CFLAGS: -I${SRCDIR}/deps/osx/include
-// #cgo linux CFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo linux CFLAGS: -I/usr/local/include
 // #cgo CXXFLAGS: -std=c++11
-// #cgo darwin CXXFLAGS: -I${SRCDIR}/deps/osx/include
-// #cgo linux CXXFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo linux CXXFLAGS: -I/usr/local/include
 // #cgo LDFLAGS: -lswscale -lavformat -lavcodec -lavfilter -lavutil -lbz2 -lz
-// #cgo darwin LDFLAGS: -L${SRCDIR}/deps/osx/lib
-// #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux/lib
+// #cgo linux LDFLAGS: -L/usr/local/lib
 // #include "avcodec.hpp"
 import "C"
 

--- a/avcodec.hpp
+++ b/avcodec.hpp
@@ -1,7 +1,7 @@
 #ifndef LILLIPUT_AVCODEC_HPP
 #define LILLIPUT_AVCODEC_HPP
 
-#include "opencv.hpp"
+#include <opencv2/opencv.hpp>
 
 #ifdef __cplusplus
 extern "C" {

--- a/giflib.go
+++ b/giflib.go
@@ -1,14 +1,11 @@
 package lilliput
 
 // #cgo CFLAGS: -msse -msse2 -msse3 -msse4.1 -msse4.2 -mavx
-// #cgo darwin CFLAGS: -I${SRCDIR}/deps/osx/include
-// #cgo linux CFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo linux CFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
 // #cgo CXXFLAGS: -std=c++11
-// #cgo darwin CXXFLAGS: -I${SRCDIR}/deps/osx/include
-// #cgo linux CXXFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo linux CXXFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
 // #cgo LDFLAGS:  -lopencv_core -lopencv_imgcodecs -lopencv_imgproc -ljpeg -lpng -lwebp -lippicv -lz -lgif
-// #cgo darwin LDFLAGS: -L${SRCDIR}/deps/osx/lib -L${SRCDIR}/deps/osx/share/OpenCV/3rdparty/lib
-// #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux/lib -L${SRCDIR}/deps/linux/share/OpenCV/3rdparty/lib
+// #cgo linux LDFLAGS: -L/usr/local/lib -L/usr/local/lib/opencv4/3rdparty
 // #include "giflib.hpp"
 import "C"
 

--- a/giflib.hpp
+++ b/giflib.hpp
@@ -1,7 +1,7 @@
 #ifndef LILLIPUT_GIFLIB_HPP
 #define LILLIPUT_GIFLIB_HPP
 
-#include "opencv.hpp"
+#include <opencv2/opencv.hpp>
 
 #ifdef __cplusplus
 extern "C" {

--- a/opencv.cpp
+++ b/opencv.cpp
@@ -1,4 +1,4 @@
-#include "opencv.hpp"
+#include <opencv2/opencv.hpp>
 #include <stdbool.h>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>

--- a/opencv.go
+++ b/opencv.go
@@ -6,7 +6,7 @@ package lilliput
 // #cgo linux CXXFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
 // #cgo LDFLAGS:  -lopencv_core -lopencv_imgcodecs -lopencv_imgproc -ljpeg -lpng -lwebp -lippicv -lz
 // #cgo linux LDFLAGS: -L/usr/local/lib -L/usr/local/lib/opencv4/3rdparty
-// #include "opencv.hpp"
+// #include <opencv2/opencv.hpp>
 import "C"
 
 import (

--- a/opencv.go
+++ b/opencv.go
@@ -1,14 +1,11 @@
 package lilliput
 
 // #cgo CFLAGS: -msse -msse2 -msse3 -msse4.1 -msse4.2 -mavx
-// #cgo darwin CFLAGS: -I${SRCDIR}/deps/osx/include
-// #cgo linux CFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo linux CFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
 // #cgo CXXFLAGS: -std=c++11
-// #cgo darwin CXXFLAGS: -I${SRCDIR}/deps/osx/include
-// #cgo linux CXXFLAGS: -I${SRCDIR}/deps/linux/include
+// #cgo linux CXXFLAGS: -I/usr/local/include -I/usr/local/include/opencv4
 // #cgo LDFLAGS:  -lopencv_core -lopencv_imgcodecs -lopencv_imgproc -ljpeg -lpng -lwebp -lippicv -lz
-// #cgo darwin LDFLAGS: -L${SRCDIR}/deps/osx/lib -L${SRCDIR}/deps/osx/share/OpenCV/3rdparty/lib
-// #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux/lib -L${SRCDIR}/deps/linux/share/OpenCV/3rdparty/lib
+// #cgo linux LDFLAGS: -L/usr/local/lib -L/usr/local/lib/opencv4/3rdparty
 // #include "opencv.hpp"
 import "C"
 


### PR DESCRIPTION
Reference to gocv, they use the `/usr/loca/` path for cgo and works. Thus, tried to deprecate the build script which will download the outdated deps.

The giflib still needed since it contains the patch from discord.